### PR TITLE
Added ChangedContentChannelItemsByDate Endpoint

### DIFF
--- a/apollosproject.ApollosPlugin/Rest/ApollosController.cs
+++ b/apollosproject.ApollosPlugin/Rest/ApollosController.cs
@@ -18,6 +18,9 @@ using System.Data.Entity;
 
 namespace apollosproject.ApollosPlugin.Rest
 {
+    /// <summary>
+    /// API Controller for Apollos Project Rock REST endpoints
+    /// </summary>
     public class ApollosController : ApiControllerBase
     {
 
@@ -387,6 +390,39 @@ namespace apollosproject.ApollosPlugin.Rest
                 .AsQueryable();
         }
 
+        #endregion
+
+        #region GetChangedContentChannelItemsByDate
+        /// <summary>
+        /// Returns a list of content channel items that:
+        /// (a) were created or changed since the passed in date.
+        /// (b) had attributes that were created or changed since the passed in date.
+        /// </summary>
+        [HttpGet]
+        [EnableQuery]
+        [Authenticate, Secured]
+        [System.Web.Http.Route("api/Apollos/ChangedContentChannelItemsByDate")]
+        public IQueryable<ContentChannelItem> ChangedContentChannelItemsByDate(DateTime changedSinceDate)
+        {
+            // I want to return two things:
+            // 1. A list of content channel items that were created OR changed since the changedSinceDate.
+            // 2. A list of content channel items whose attributes were created OR changed since the changedSinceDate.
+            // Should also support all the nornal ODATA stuff (sorting and filtering and such).
+
+            RockContext rockContext = new RockContext();
+            IQueryable<ContentChannelItem> contentChannelItemList = new ContentChannelItemService(rockContext)
+                .Queryable()
+                .AsNoTracking()
+                .Where(cci => cci.CreatedDateTime >= changedSinceDate || cci.ModifiedDateTime >= changedSinceDate);
+
+
+            IQueryable<ContentChannelItem> contentChannelItemList2 = new ContentChannelItemService(rockContext)
+                .Queryable()
+                .AsNoTracking()
+                .WhereAttributeValue(rockContext, a => a.CreatedDateTime >= changedSinceDate || a.ModifiedDateTime >= changedSinceDate);
+
+            return contentChannelItemList.Union(contentChannelItemList2).AsQueryable();
+        }
         #endregion
 
     }

--- a/apollosproject.ApollosPlugin/apollosproject.ApollosPlugin.csproj
+++ b/apollosproject.ApollosPlugin/apollosproject.ApollosPlugin.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>apollosproject.ApollosPlugin</RootNamespace>
     <AssemblyName>apollosproject.ApollosPlugin</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
@@ -33,20 +33,32 @@
     <DocumentationFile>bin\Release\apollosproject.ApollosPlugin.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Rock, Version=1.9.0.23, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\RockWeb\Bin\Rock.dll</HintPath>
+    <Reference Include="EntityFramework">
+      <HintPath>..\..\Rock\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Rock">
+      <HintPath>..\..\Rock\RockWeb\Bin\Rock.dll</HintPath>
+    </Reference>
+    <Reference Include="Rock.Common">
+      <HintPath>..\..\Rock\RockWeb\Bin\Rock.Common.dll</HintPath>
     </Reference>
     <Reference Include="Rock.Rest">
-      <HintPath>..\RockWeb\Bin\Rock.Rest.dll</HintPath>
+      <HintPath>..\..\Rock\RockWeb\Bin\Rock.Rest.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.Entity" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http">
+      <HintPath>..\..\Rock\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.OData">
+      <HintPath>..\..\Rock\packages\Microsoft.AspNet.WebApi.OData.5.7.0\lib\net45\System.Web.Http.OData.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />

--- a/apollosproject.ApollosPlugin/apollosproject.ApollosPlugin.sln
+++ b/apollosproject.ApollosPlugin/apollosproject.ApollosPlugin.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31702.278
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "apollosproject.ApollosPlugin", "apollosproject.ApollosPlugin.csproj", "{8A4624C5-1808-4CA1-B9D9-1109B467FE39}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8A4624C5-1808-4CA1-B9D9-1109B467FE39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A4624C5-1808-4CA1-B9D9-1109B467FE39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A4624C5-1808-4CA1-B9D9-1109B467FE39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A4624C5-1808-4CA1-B9D9-1109B467FE39}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2B29CD3D-79B2-4988-B893-20BAECB46EAF}
+	EndGlobalSection
+EndGlobal

--- a/apollosproject.ApollosPlugin/packages.config
+++ b/apollosproject.ApollosPlugin/packages.config
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
-  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net452" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
-  <package id="Microsoft.AspNet.WebApi.OData" version="5.7.0" targetFramework="net452" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net452" />
-  <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net452" />
-  <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="System.Spatial" version="5.6.0" targetFramework="net452" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.OData" version="5.7.0" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net472" />
+  <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net472" />
+  <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net472" />
+  <package id="System.Spatial" version="5.6.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
This PR adds an API endpoint (`ChangedContentChannelItemsByDate`) that:
* Gets all content channel items that have been changed or created since a certain date, _and_
* Gets all content channel items that have had their attribute values changed or updated after said date, _and_
* Should allow for all the normal `ODATA` filtering and such.

I changed a couple of items in my local Rock instance and gave a `changedSinceDate` of yesterday and it returned those couple of items.

![Screen Shot 2021-09-20 at 6 11 35 PM](https://user-images.githubusercontent.com/3229463/134082754-4a30fc2f-58f4-4531-b009-84173a44f189.png)


